### PR TITLE
Setuped basic API handler for user prompts

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -1,14 +1,19 @@
 package main
 
 import (
-	"fmt"
+	"ai-orchestrator/internal/config"
+	"ai-orchestrator/internal/server"
+	"log"
+	"log/slog"
 )
 
 func main() {
-	s := "gopher"
-	fmt.Printf("Hello and welcome, %s!\n", s)
-
-	for i := 1; i <= 5; i++ {
-		fmt.Println("i =", 100/i)
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		log.Fatalf("failed to load config: %v", err)
 	}
+	logger := cfg.ConfigureLogger(slog.LevelInfo)
+
+	srvr := server.SetupServer(cfg, logger)
+	server.GracefulShutdown(srvr, logger)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
 module ai-orchestrator
 
 go 1.24
+
+require (
+	github.com/gorilla/mux v1.8.1
+	go-simpler.org/env v0.12.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
+github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
+go-simpler.org/env v0.12.0 h1:kt/lBts0J1kjWJAnB740goNdvwNxt5emhYngL0Fzufs=
+go-simpler.org/env v0.12.0/go.mod h1:cc/5Md9JCUM7LVLtN0HYjPTDcI3Q8TDaPlNTAlDU+WI=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,1 +1,27 @@
 package config
+
+import (
+	"go-simpler.org/env"
+	"log/slog"
+	"os"
+)
+
+type Config struct {
+	AppPort string `env:"PORT,required"`
+}
+
+func LoadConfig() (*Config, error) {
+	cfg := &Config{}
+	err := env.Load(cfg, nil)
+	if err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+func (cfg *Config) ConfigureLogger(level slog.Level) *slog.Logger {
+	handler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: level,
+	})
+	return slog.New(handler)
+}

--- a/internal/custom_error/ErrinvalidPayload.go
+++ b/internal/custom_error/ErrinvalidPayload.go
@@ -1,0 +1,13 @@
+package custom_error
+
+type InvalidPayloadError struct {
+	Message string
+}
+
+func (e *InvalidPayloadError) Error() string {
+	return e.Message
+}
+
+func NewErrInvalidPayload(message string) error {
+	return &InvalidPayloadError{message}
+}

--- a/internal/handler/prompt/prompt.go
+++ b/internal/handler/prompt/prompt.go
@@ -1,0 +1,47 @@
+package prompt
+
+import (
+	"ai-orchestrator/internal/util"
+	"net/http"
+)
+
+type Logger interface {
+	Info(msg string, args ...any)
+	Warn(msg string, args ...any)
+}
+
+type Service interface {
+}
+
+type Handler struct {
+	logger Logger
+}
+
+type CreateRequest struct {
+	UserID string `json:"user_id"`
+	Prompt string `json:"prompt"`
+}
+
+func NewHandler(l Logger) *Handler {
+	return &Handler{l}
+}
+
+func (h *Handler) PostPrompt(rw http.ResponseWriter, r *http.Request) {
+	h.logger.Info("Incoming request:", "path", "promptHandler.PostPrompt")
+
+	userPrompt := &CreateRequest{}
+	err := util.FromJSON(r.Body, userPrompt)
+	if err != nil {
+		h.logger.Warn("failed to decode request body", "error", err, "request_body", r.Body, "handler", "promptHandler.PostPrompt")
+		util.WriteJSONError(rw, http.StatusBadRequest, "invalid request body", nil)
+		return
+	}
+
+	// process with service
+
+	util.WriteJSONResponse(rw, http.StatusAccepted, &struct {
+		Message string
+	}{
+		Message: "Prompt accepted",
+	})
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,0 +1,60 @@
+package server
+
+import (
+	"ai-orchestrator/internal/config"
+	"ai-orchestrator/internal/handler/prompt"
+	"context"
+	"errors"
+	"github.com/gorilla/mux"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+)
+
+func SetupServer(cfg *config.Config, logger *slog.Logger) *http.Server {
+	promptHandler := prompt.NewHandler(logger)
+
+	r := registerRoutes(promptHandler)
+	logger.Info("Starting server")
+
+	return &http.Server{
+		Addr:         ":" + cfg.AppPort,
+		Handler:      r,
+		IdleTimeout:  120 * time.Second,
+		ReadTimeout:  1 * time.Second,
+		WriteTimeout: 1 * time.Second,
+	}
+}
+
+func registerRoutes(handler *prompt.Handler) *mux.Router {
+	r := mux.NewRouter()
+
+	r.HandleFunc("/ask", handler.PostPrompt).Methods(http.MethodPost)
+
+	return r
+}
+
+func GracefulShutdown(server *http.Server, logger *slog.Logger) {
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+
+	go func() {
+		logger.Info("starting HTTP server", "addr", server.Addr, "idle_timeout", server.IdleTimeout, "read_timeout", server.ReadTimeout, "write_timeout", server.WriteTimeout)
+		if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			logger.Error("error occurred when starting server", "error", err)
+		}
+	}()
+
+	sig := <-sigChan
+	logger.Info("received terminate, graceful shutdown", "sig", sig)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	if err := server.Shutdown(ctx); err != nil {
+		logger.Error("error during server shutdown", "error", err, "addr", server.Addr)
+	}
+}

--- a/internal/util/req_res_helper.go
+++ b/internal/util/req_res_helper.go
@@ -1,0 +1,45 @@
+package util
+
+import (
+	"ai-orchestrator/internal/custom_error"
+	"encoding/json"
+	"io"
+	"net/http"
+)
+
+func FromJSON(r io.Reader, entity any) error {
+	err := json.NewDecoder(r).Decode(entity)
+	if err != nil {
+		return custom_error.NewErrInvalidPayload(err.Error())
+	}
+	return nil
+}
+
+func ToJSON(w io.Writer, entity any) error {
+	return json.NewEncoder(w).Encode(entity)
+}
+
+func WriteJSONError(w http.ResponseWriter, httpStatus int, message string, err error) {
+	response := map[string]string{
+		"message": message,
+	}
+	if err != nil {
+		response["error"] = err.Error()
+	}
+	WriteJSONResponse(w, httpStatus, response)
+}
+
+func WriteJSONResponse(w http.ResponseWriter, httpStatus int, entity any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(httpStatus)
+	err := ToJSON(w, entity)
+	if err != nil {
+		err = ToJSON(w, map[string]string{
+			"message": "failed to return object",
+		})
+		// If writing JSON response fails, don't keep trying, just send status code.
+		if err != nil {
+			return
+		}
+	}
+}


### PR DESCRIPTION
This pull request introduces the initial structure for the `ai-orchestrator` API server, implementing configuration management, HTTP routing, structured logging, error handling, and a basic `/ask` endpoint for prompt submission. The changes lay the foundation for a scalable and maintainable web service by organizing code into logical modules and introducing best practices for configuration and request handling.

**Server setup and routing:**
* Added a new `internal/server/server.go` module to encapsulate server setup, route registration (using Gorilla Mux), and graceful shutdown logic with structured logging. The server exposes a `/ask` POST endpoint handled by the prompt handler.

**Configuration and logging:**
* Introduced the `internal/config/config.go` module to load configuration from environment variables (using `go-simpler.org/env`) and provide a method for structured JSON logging via the standard library's `slog` package.
* Updated the main entrypoint (`cmd/api/main.go`) to use the new configuration and logging setup, replacing the previous placeholder code.

**Request handling and utilities:**
* Created the `internal/handler/prompt/prompt.go` module to handle `/ask` POST requests, including request body decoding, logging, and response writing.
* Added utility functions in `internal/util/req_res_helper.go` for JSON serialization/deserialization and standardized HTTP response writing, including error handling.
* Defined a custom error type for invalid payloads in `internal/custom_error/ErrinvalidPayload.go` to improve error reporting and handling.

**Dependency management:**
* Updated `go.mod` to include dependencies for routing (`github.com/gorilla/mux`) and environment variable management (`go-simpler.org/env`).