### PR TITLE
Implemented repository for prompt.

### DIFF
--- a/internal/domain/service/prompt/service.go
+++ b/internal/domain/service/prompt/service.go
@@ -11,6 +11,7 @@ type TaskProducer interface {
 }
 
 type Repository interface {
+	InsertPrompt(ctx context.Context, prompt model.Prompt) error
 }
 
 type Service struct {
@@ -24,13 +25,15 @@ func NewService(l common.Logger, s TaskProducer, repository Repository) *Service
 }
 
 func (s *Service) PostPrompt(ctx context.Context, prompt model.Prompt) error {
-	// TODO: Save to repository
+	prompt.Status = model.Accepted
 
-	// TODO: publish
-	err := s.tasks.Publish(ctx, prompt)
+	err := s.repo.InsertPrompt(ctx, prompt)
 	if err != nil {
 		return err
 	}
-	// Later there will be no return value, since error will be handled automatically via the Outbox pattern.
+	err = s.tasks.Publish(ctx, prompt)
+	if err != nil {
+		return err
+	}
 	return nil
 }

--- a/internal/infra/persistence/repository/prompt/prompt.go
+++ b/internal/infra/persistence/repository/prompt/prompt.go
@@ -1,6 +1,7 @@
 package prompt
 
 import (
+	"ai-orchestrator/internal/domain/model"
 	"github.com/google/uuid"
 	"time"
 )
@@ -12,4 +13,13 @@ type Prompt struct {
 	Status    string    `db:"status"`
 	CreatedAt time.Time `db:"created_at"`
 	UpdatedAt time.Time `db:"updated_at"`
+}
+
+func FromDomain(d model.Prompt) Prompt {
+	return Prompt{
+		Id:     d.ID,
+		UserID: d.UserID,
+		Text:   d.Text,
+		Status: string(d.Status),
+	}
 }

--- a/internal/infra/persistence/repository/prompt/repository.go
+++ b/internal/infra/persistence/repository/prompt/repository.go
@@ -2,7 +2,10 @@ package prompt
 
 import (
 	"ai-orchestrator/internal/common"
+	"ai-orchestrator/internal/domain/model"
+	"context"
 	"github.com/jmoiron/sqlx"
+	"time"
 )
 
 type Repository struct {
@@ -15,4 +18,25 @@ func NewRepository(logger common.Logger, db *sqlx.DB) *Repository {
 		logger: logger,
 		db:     db,
 	}
+}
+
+func (r *Repository) InsertPrompt(ctx context.Context, prompt model.Prompt) error {
+	dbPrompt := FromDomain(prompt)
+	dbPrompt.CreatedAt = time.Now()
+	dbPrompt.UpdatedAt = dbPrompt.CreatedAt
+
+	query := `
+		INSERT INTO prompts (id, user_id, text, status, created_at, updated_at)
+		VALUES (:id, :user_id, :text, :status, :created_at, :updated_at)
+	`
+
+	r.logger.Info("executing query to insert new project", "query", query, "repository", "projectRepository")
+
+	_, err := r.db.NamedExecContext(ctx, query, dbPrompt)
+	if err != nil {
+		r.logger.Error("failed to insert new project", "error", err)
+		return err
+	}
+
+	return nil
 }

--- a/internal/infra/persistence/repository/prompt/repository.go
+++ b/internal/infra/persistence/repository/prompt/repository.go
@@ -22,7 +22,7 @@ func NewRepository(logger common.Logger, db *sqlx.DB) *Repository {
 
 func (r *Repository) InsertPrompt(ctx context.Context, prompt model.Prompt) error {
 	dbPrompt := FromDomain(prompt)
-	dbPrompt.CreatedAt = time.Now()
+	dbPrompt.CreatedAt = time.Now().UTC()
 	dbPrompt.UpdatedAt = dbPrompt.CreatedAt
 
 	query := `

--- a/internal/infra/persistence/repository/prompt/repository.go
+++ b/internal/infra/persistence/repository/prompt/repository.go
@@ -30,11 +30,11 @@ func (r *Repository) InsertPrompt(ctx context.Context, prompt model.Prompt) erro
 		VALUES (:id, :user_id, :text, :status, :created_at, :updated_at)
 	`
 
-	r.logger.Info("executing query to insert new project", "query", query, "repository", "projectRepository")
+	r.logger.Info("executing query to insert new prompt", "query", query, "repository", "promptRepository")
 
 	_, err := r.db.NamedExecContext(ctx, query, dbPrompt)
 	if err != nil {
-		r.logger.Error("failed to insert new project", "error", err)
+		r.logger.Error("failed to insert new prompt", "error", err)
 		return err
 	}
 


### PR DESCRIPTION
This pull request implements prompt persistence in the repository layer and updates the service logic to save prompts before publishing them. The main changes introduce a new `InsertPrompt` method, ensure prompts are stored in the database before being published, and provide a mapping from domain to database models.

**Repository persistence and service flow improvements:**

* Added `InsertPrompt` method to the `Repository` interface and implemented it in the repository, enabling prompts to be saved to the database with timestamps before further processing. [[1]](diffhunk://#diff-2314a9e37c4090a9b470c9e7b28250ea1ac4ea28724b32ff1a761a9bd8724460R14) [[2]](diffhunk://#diff-ba6130b748b6221e85c31dce6bdc015b52f980793b9473656145b232347a2a44R22-R42)
* Updated the `PostPrompt` service method to first persist the prompt using `InsertPrompt` and only publish it if saving succeeds, improving reliability and data consistency.

**Domain–database model mapping:**

* Added a `FromDomain` function to convert a `model.Prompt` to the database `Prompt` struct, standardizing data transformation between layers.

**Dependency and import updates:**

* Added necessary imports for `model`, `context`, and `time` in repository files to support the new persistence logic. [[1]](diffhunk://#diff-3fc8a9bac664c183857214138b10c84c4c3e151064916558ad09a236b88f3c18R4) [[2]](diffhunk://#diff-ba6130b748b6221e85c31dce6bdc015b52f980793b9473656145b232347a2a44R5-R8)